### PR TITLE
Docs: Specs & New-Chat starter for Aim2 Dartboard Invaders

### DIFF
--- a/Assets/Aim2.meta
+++ b/Assets/Aim2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 421560c91369d4f6c937230e387bee6e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aim2/Invaders.meta
+++ b/Assets/Aim2/Invaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71a88ba9f58e14bbd8c2396b877dd986
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aim2/Invaders/Aim2InvadersBootstrap.cs.meta
+++ b/Assets/Aim2/Invaders/Aim2InvadersBootstrap.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd5d9d05ee90248fb828d97610aab521

--- a/Assets/Aim2/Invaders/Bullet.cs.meta
+++ b/Assets/Aim2/Invaders/Bullet.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1d82420919ea641e1a5e750d49a7ad0e

--- a/Assets/Aim2/Invaders/EnemyFormation.cs.meta
+++ b/Assets/Aim2/Invaders/EnemyFormation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6ebd01fb62b874cf88d4988eed34d3cb

--- a/Assets/Aim2/Invaders/EnemyMarker.cs.meta
+++ b/Assets/Aim2/Invaders/EnemyMarker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b050ea4c5e394c03b01bc24b4575773

--- a/Assets/Aim2/Invaders/PlayerController.cs.meta
+++ b/Assets/Aim2/Invaders/PlayerController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e5ce325c90c074d688f294054a09c4bd

--- a/StickerDash_Status/Notes.md
+++ b/StickerDash_Status/Notes.md
@@ -1,0 +1,1 @@
+- 2025-10-01 Specs + New-Chat prompt added for Aim2 Dartboard Invaders.

--- a/StickerDash_Status/Prompts/NewChat_Aim2_Dartboard_Invaders.txt
+++ b/StickerDash_Status/Prompts/NewChat_Aim2_Dartboard_Invaders.txt
@@ -1,0 +1,34 @@
+I’m Andy. Project = Aim2 Dartboard Invaders (Unity 2D, fixed-shooter).
+Fast mode: concise + bash-first. Deliver patches as ONE bash script that writes files, then git-commits to a feature branch and pushes. If `gh` is installed, open a PR.
+
+Ground rules:
+- One editor window only: Window > Aim2Pro > Track Creator > Track Lab (All-in-One)
+- Units: meters; tiles must touch; default width 3m unless I say otherwise.
+- Repo: git@github.com:andycann44/Aim2-Dartboard-invaders.git
+- Platform: macOS (bash). No VS Code steps; script everything.
+
+What exists now (v0.1 MVP):
+- Runtime bootstrap builds a playable scene: player left/right + shoot; enemy formation marches; bullets kill; mini HUD; win + R to restart.
+- Specs file lives at StickerDash_Status/Specs/Aim2-Dartboard-Invaders_Spec.md
+
+What I want next (pick a tight slice and ship it):
+- Enemy shooting + player lives + Game Over + score/high score
+- Or: proper HUD + simple SFX
+- Or: on-screen mobile controls + Android dev build script
+
+Your response format every time:
+1) **Plan (very short)** — bullet steps for the chosen slice.
+2) **Patch (bash script)** — creates/updates files under Assets/… etc., idempotent, with:
+   - `#!/usr/bin/env bash`, `set -euo pipefail`
+   - Writes files, then:
+     ```
+     BR="a2p/$(date +%Y-%m-%d)-<slug>"
+     git checkout -b "$BR" || git checkout "$BR"
+     git add -A
+     git commit -m "<clear message>"
+     git push -u origin "$BR"
+     command -v gh >/dev/null && gh pr create -t "<title>" -b "<notes>" -B main || true
+     ```
+3) **How to test** — exact steps in Unity (Play/keys), plus expected result.
+
+Never rename or add extra editor windows. Keep things small and shippable.

--- a/StickerDash_Status/Specs/Aim2-Dartboard-Invaders_Spec.md
+++ b/StickerDash_Status/Specs/Aim2-Dartboard-Invaders_Spec.md
@@ -1,0 +1,60 @@
+# Aim2 Dartboard Invaders — Spec & Roadmap v0.1
+**Date:** 2025-10-01  
+**Repo:** git@github.com:andycann44/Aim2-Dartboard-invaders.git  
+**Company/Brand:** Aim2 (sub-brand Aim2Pro for darts)  
+**Editor Window Rule:** Window → Aim2Pro → Track Creator → Track Lab (All-in-One) only.
+
+## Overview
+Fixed-shooter (arcade homage) built from our Aim2 template. Clean, fast sessions (60–90s), original IP (Johnny + Aim2 style), ethical monetization.
+
+## Current Implementation (MVP runtime bootstrap)
+- Bootstrap builds a playable scene at runtime.
+- Player: left/right move (A/D or arrows), shoot (Space/mouse), screen-edge clamp.
+- Bullet: kinematic, destroys enemies on hit.
+- Enemy formation: grid spawns, marches left↔right, steps down at edges.
+- HUD mini: shows destroyed count; win state + press **R** to restart.
+- URP 2D; simple generated sprites (no imported art yet).
+
+## “Done” Checklist
+- [x] Repo created & wired to GitHub
+- [x] Visible Meta Files + Force Text (Unity project hygiene)
+- [x] Runtime playable loop (player, bullets, invaders, win/restart)
+- [x] Specs + New-Chat starter files added (this commit)
+
+## To-Do (next passes)
+**Core gameplay**
+- [ ] Enemy shots + player hit detection
+- [ ] Lives (e.g., 3) + Game Over screen
+- [ ] Score system (per kill) + High Score (PlayerPrefs)
+- [ ] Speed up as invaders die, wave progression
+
+**UX/UI**
+- [ ] Main menu, Pause, Settings
+- [ ] Proper HUD (lives, score, wave), fonts/icons (Aim2 style)
+
+**Audio**
+- [ ] SFX (shoot, hit, step, win/lose), music loop, simple mixer
+
+**Art**
+- [ ] Swap generated shapes for Aim2 sprites (Johnny ship + enemies)
+- [ ] Palette + background, small VFX on hit
+
+**Monetization & Growth (stubs first)**
+- [ ] Rewarded continue (stub), Remove Ads (non-consumable), Starter Pack
+- [ ] “More Games” panel (reads StickerDash_Status/CrossPromo/more_games.json)
+- [ ] Basic analytics events (session/level/kill/death/revive)
+
+**Mobile readiness**
+- [ ] On-screen controls (left/right/shoot) + aspect handling
+- [ ] Android/iOS dev builds; tag v0.1.0
+
+**Compliance**
+- [ ] Privacy link + consent (GDPR/ATT), restore purchases (iOS)
+
+## Definition of Done (v0.2 “Playable Mobile”)
+- Player lives, enemy fire, game over, score/high score.
+- One rewarded continue (stub), Remove Ads button visible.
+- Android dev build installs; 60 FPS on test phone; no red console errors.
+
+## Notes
+Keep one editor window (Track Lab). Units default to meters; tiles must touch; width 3m unless overridden. Use `./a2p_snap.sh` before risky changes. Tag releases (`v0.1.0`, `v0.2.0`, …) instead of making new repos.


### PR DESCRIPTION
Adds project spec/roadmap and a ready-to-paste New-Chat prompt under StickerDash_Status.